### PR TITLE
Feature/environment variable handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,38 +8,6 @@ A Python script that generates SRT subtitle files from audio files using DaVinci
 2. **Python 3.6+** (64-bit version)
 3. **Required Python packages** (install using `pip install -r requirements.txt`)
 
-## Environment Setup
-
-Before running the script, you need to set up the following environment variables (figure out your paths if necessary):
-
-### Windows
-```powershell
-$env:RESOLVE_SCRIPT_API = "C:\ProgramData\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting"
-$env:RESOLVE_SCRIPT_LIB = "C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll"
-$env:PYTHONPATH = "$env:PYTHONPATH;$env:RESOLVE_SCRIPT_API\Modules"
-```
-
-**Note**: You may consider making it permantent by going to `sysdm.cpl` and changing user environment variables from there. Set those three variables above to their values.
-
-### macOS
-```bash
-export RESOLVE_SCRIPT_API="/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting"
-export RESOLVE_SCRIPT_LIB="/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion/fusionscript.so"
-export PYTHONPATH="$PYTHONPATH:$RESOLVE_SCRIPT_API/Modules"
-```
-
-**Note**: You can permanently set environment variables in macOS by adding them to your shell configuration file (e.g., `~/.bash_profile`, `~/.zshrc`, or `~/.bashrc`). Add the following lines to the file:
-
-### Linux
-```bash
-export RESOLVE_SCRIPT_API="/opt/resolve/Developer/Scripting"
-export RESOLVE_SCRIPT_LIB="/opt/resolve/libs/Fusion/fusionscript.so"
-export PYTHONPATH="$PYTHONPATH:$RESOLVE_SCRIPT_API/Modules"
-```
-
-**Note**: To permanently set environment variables in Linux, you can add them to your shell configuration file. For example, you can add the following lines to your `~/.bashrc` or `~/.bash_profile` file:
-
-
 ## Usage
 
 1. **Start DaVinci Resolve** and create a new project or open an existing one. It won't work without Resolve running as it still uses the UI for functionality, but still fortunately in an automated way.
@@ -81,7 +49,7 @@ For each input audio file, a corresponding SRT file will be created in the same 
 
 If you encounter issues:
 1. Ensure DaVinci Resolve is running and a project is open
-2. Verify the environment variables are set correctly
+2. Verify the environment variables are set correctly, which the program should let you define via user input if it isn't correct
 3. Check that you have the required Python packages installed
 4. Make sure you have write permissions in the output directory
 

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -17,29 +17,26 @@ import csv
 logging.basicConfig(level=logging.INFO)
 
 def find_module_locations(base_path):
-    """Find DaVinciResolveScript.py at the exact path specified.
-    ONLY checks for the module file at exactly the path provided, with no alternate locations.
-    This ensures we never check multiple locations or parent/child directories."""
+    """Find possible locations of DaVinciResolveScript.py based on a base path.
+    Only checks the standard location and directly in the specified path."""
     locations = []
     module_paths = []
     
-    # Check ONLY for the module file at the exact path specified
-    module_path = os.path.join(base_path, "DaVinciResolveScript.py")
-    print(f"\nChecking for module at ONLY this exact location:")
-    print(f"  {module_path}")
-    print(f"  No other locations will be checked.")
-    
-    if os.path.isfile(module_path):
+    # Check standard location (base_path/Modules/DaVinciResolveScript.py)
+    standard_location = os.path.join(base_path, "Modules", "DaVinciResolveScript.py")
+    if os.path.isfile(standard_location):
+        locations.append(os.path.dirname(standard_location))
+        module_paths.append(standard_location)
+        
+    # Check directly in base path (base_path/DaVinciResolveScript.py)
+    direct_location = os.path.join(base_path, "DaVinciResolveScript.py")
+    if os.path.isfile(direct_location):
         locations.append(base_path)
-        module_paths.append(module_path)
-        print(f"Found module at: {module_path}")
-        print(f"Adding exact directory to path: {base_path}")
-    else:
-        print(f"Module NOT found at: {module_path}")
+        module_paths.append(direct_location)
     
     return {
-        "locations": locations,  # Directory containing the module (exactly one or none)
-        "module_paths": module_paths  # Full path to the module file (exactly one or none)
+        "locations": locations,  # Directories containing the module
+        "module_paths": module_paths  # Full paths to the module files
     }
 
 def validate_resolve_paths():
@@ -161,62 +158,46 @@ def validate_resolve_paths():
             else:
                 # Use custom path
                 custom_path = use_default
-                path_set = False
-                
-                # Check if the path is a file
+                # Check if they provided the file itself or just a directory
                 if os.path.isfile(custom_path):
-                    # User provided the actual file path - use ONLY the exact directory containing the file
+                    # User provided the actual file path
+                    module_dir = os.path.dirname(custom_path)
                     if os.path.basename(custom_path) == "DaVinciResolveScript.py":
-                        # Set the exact directory containing the file as API path
-                        module_dir = os.path.dirname(custom_path)
+                        # Set the parent directory as API path
+                        api_parent = os.path.dirname(module_dir) if os.path.basename(module_dir) == "Modules" else module_dir
+                        os.environ["RESOLVE_SCRIPT_API"] = api_parent
+                        api_path = api_parent
+                        config["RESOLVE_SCRIPT_API"] = api_parent
+                        modified = True
+                        print(f"Set API path to: {api_parent} (based on file: {custom_path})")
+                    else:
+                        print(f"Warning: The specified file does not appear to be DaVinciResolveScript.py")
+                        print(f"Using path anyway: {custom_path}")
                         os.environ["RESOLVE_SCRIPT_API"] = module_dir
                         api_path = module_dir
                         config["RESOLVE_SCRIPT_API"] = module_dir
                         modified = True
-                        print(f"Set API path to exact directory containing file: {module_dir}")
-                        path_set = True
-                    else:
-                        print(f"Warning: The specified file does not appear to be DaVinciResolveScript.py")
-                        retry = input("Use this path anyway? (y/n): ")
-                        if retry.lower() == 'y':
-                            module_dir = os.path.dirname(custom_path)
-                            os.environ["RESOLVE_SCRIPT_API"] = module_dir
-                            api_path = module_dir
-                            config["RESOLVE_SCRIPT_API"] = module_dir
-                            modified = True
-                            path_set = True
-                
-                # Check if the path is a directory (only if path not already set)
-                if not path_set and os.path.isdir(custom_path):
-                    # User provided a directory - use ONLY this exact directory
-                    # Check if it has the module file directly in this directory
-                    module_path = os.path.join(custom_path, "DaVinciResolveScript.py")
-                    if os.path.isfile(module_path):
-                        # Found the module in the exact directory specified
+                elif os.path.isdir(custom_path):
+                    # User provided a directory
+                    # Check if it has the module directly or in a Modules subdirectory
+                    custom_module_info = find_module_locations(custom_path)
+                    if custom_module_info["module_paths"]:
+                        # Found the module in or under the specified directory
                         os.environ["RESOLVE_SCRIPT_API"] = custom_path
                         api_path = custom_path
                         config["RESOLVE_SCRIPT_API"] = custom_path
                         modified = True
-                        print(f"Found module at: {module_path}")
-                        print(f"Set API path to exact directory: {custom_path}")
-                        path_set = True
+                        print(f"Found module at: {custom_module_info['module_paths'][0]}")
+                        print(f"Set API path to: {custom_path}")
                     else:
-                        print(f"Warning: DaVinciResolveScript.py not found at: {module_path}")
-                        retry = input("Use this path anyway? (y/n): ")
-                        if retry.lower() == 'y':
-                            os.environ["RESOLVE_SCRIPT_API"] = custom_path
-                            api_path = custom_path
-                            config["RESOLVE_SCRIPT_API"] = custom_path
-                            modified = True
-                            path_set = True
-                
-                # If path not set by any of the above, use default
-                if not path_set:
-                    if os.path.isfile(custom_path) or os.path.isdir(custom_path):
-                        print(f"Warning: DaVinciResolveScript.py not found at specified path")
-                    else:
-                        print(f"Warning: Path not found: {custom_path}")
-                    
+                        print(f"Warning: DaVinciResolveScript.py not found at or under: {custom_path}")
+                        print(f"Using path anyway: {custom_path}")
+                        os.environ["RESOLVE_SCRIPT_API"] = custom_path
+                        api_path = custom_path
+                        config["RESOLVE_SCRIPT_API"] = custom_path
+                        modified = True
+                else:
+                    print(f"Warning: Path not found: {custom_path}")
                     print(f"Using default path: {default_api_path}")
                     os.environ["RESOLVE_SCRIPT_API"] = default_api_path
                     api_path = default_api_path
@@ -226,50 +207,49 @@ def validate_resolve_paths():
         else:
             # Default doesn't exist either - keep asking until they provide a valid path
             print(f"Default module file not found at standard locations")
-            print("Please provide a valid path to DaVinciResolveScript.py or the directory containing it")
+            print("Please provide a valid path to DaVinciResolveScript.py or its parent directory")
             
             while True:
-                custom_path = input("Enter path to DaVinciResolveScript.py or its containing directory: ")
+                custom_path = input("Enter path to DaVinciResolveScript.py or its parent directory: ")
                 if not custom_path.strip():
                     print("Error: A path must be provided.")
                     continue
                 
                 if os.path.isfile(custom_path):
-                    # User provided the actual file path - use ONLY the exact directory containing the file
+                    # User provided the actual file path
+                    module_dir = os.path.dirname(custom_path)
                     if os.path.basename(custom_path) == "DaVinciResolveScript.py":
-                        # Set the exact directory containing the file as API path
-                        module_dir = os.path.dirname(custom_path)
-                        os.environ["RESOLVE_SCRIPT_API"] = module_dir
-                        api_path = module_dir
-                        config["RESOLVE_SCRIPT_API"] = module_dir
+                        # Set the parent directory as API path
+                        api_parent = os.path.dirname(module_dir) if os.path.basename(module_dir) == "Modules" else module_dir
+                        os.environ["RESOLVE_SCRIPT_API"] = api_parent
+                        api_path = api_parent
+                        config["RESOLVE_SCRIPT_API"] = api_parent
                         modified = True
-                        print(f"Set API path to exact directory containing file: {module_dir}")
+                        print(f"Set API path to: {api_parent} (based on file: {custom_path})")
                         break
                     else:
                         print(f"Warning: The specified file does not appear to be DaVinciResolveScript.py")
                         retry = input("Use this path anyway? (y/n): ")
                         if retry.lower() == 'y':
-                            module_dir = os.path.dirname(custom_path)
                             os.environ["RESOLVE_SCRIPT_API"] = module_dir
                             api_path = module_dir
                             config["RESOLVE_SCRIPT_API"] = module_dir
                             modified = True
                             break
                 elif os.path.isdir(custom_path):
-                    # User provided a directory - use ONLY this exact directory
-                    # Check if it has the module file directly in this directory
-                    module_path = os.path.join(custom_path, "DaVinciResolveScript.py")
-                    if os.path.isfile(module_path):
-                        # Found the module in the exact directory specified
+                    # User provided a directory
+                    custom_module_info = find_module_locations(custom_path)
+                    if custom_module_info["module_paths"]:
+                        # Found the module in or under the specified directory
                         os.environ["RESOLVE_SCRIPT_API"] = custom_path
                         api_path = custom_path
                         config["RESOLVE_SCRIPT_API"] = custom_path
                         modified = True
-                        print(f"Found module at: {module_path}")
-                        print(f"Set API path to exact directory: {custom_path}")
+                        print(f"Found module at: {custom_module_info['module_paths'][0]}")
+                        print(f"Set API path to: {custom_path}")
                         break
                     else:
-                        print(f"Warning: DaVinciResolveScript.py not found at: {module_path}")
+                        print(f"Warning: DaVinciResolveScript.py not found at or under: {custom_path}")
                         retry = input("Use this path anyway? (y/n): ")
                         if retry.lower() == 'y':
                             os.environ["RESOLVE_SCRIPT_API"] = custom_path
@@ -279,7 +259,6 @@ def validate_resolve_paths():
                             break
                 else:
                     print(f"Error: Path not found: {custom_path}")
-                    continue
     
     # Check if library file exists
     lib_file_exists = os.path.isfile(lib_path)
@@ -359,16 +338,17 @@ def validate_resolve_paths():
     logging.info(f"Using RESOLVE_SCRIPT_API: {api_path}")
     logging.info(f"Using RESOLVE_SCRIPT_LIB: {lib_path}")
     
-    # Add ONLY the exact directory containing the module to sys.path
+    # Add all module locations to sys.path
     module_info = find_module_locations(api_path)
-    logging.info("Adding ONLY the exact directory to Python path:")
     for path in module_info["locations"]:
         if path not in sys.path:
             sys.path.append(path)
             logging.info(f"Added to Python path: {path}")
-    
-    if not module_info["locations"]:
-        logging.warning("No module locations found to add to Python path")
+            
+    # Also add the API path itself if not already added
+    if api_path and api_path not in sys.path and os.path.exists(api_path):
+        sys.path.append(api_path)
+        logging.info(f"Added API path to Python path: {api_path}")
     
     logging.info("=============================================")
     
@@ -394,28 +374,29 @@ def test_resolve_import_in_subprocess():
     api_path = os.environ.get("RESOLVE_SCRIPT_API", "")
     lib_path = os.environ.get("RESOLVE_SCRIPT_LIB", "")
     
-    # Find the module location - ONLY using the strict find_module_locations function
+    # Find all possible module locations
     module_info = find_module_locations(api_path)
     module_locations = module_info["locations"]
     module_files = module_info["module_paths"]
     
     # Print found paths for debugging
-    print("Found module locations for testing:")
+    print("Found module locations:")
     for path in module_files:
         print(f"  - {path}")
     
-    # ONLY use the exact path returned by find_module_locations
+    # Add the API path itself and its parent to search paths
     search_paths = []
+    if os.path.exists(api_path):
+        search_paths.append(api_path)
+    if os.path.exists(os.path.dirname(api_path)):
+        search_paths.append(os.path.dirname(api_path))
+        
+    # Add module locations to search paths
     for loc in module_locations:
         if loc not in search_paths and os.path.exists(loc):
             search_paths.append(loc)
     
     print(f"Search paths to be used: {search_paths}")
-    
-    # If no valid paths found, return failure
-    if not search_paths:
-        logging.error("No valid module paths found for testing")
-        return False
     
     # Create a temporary Python file with the import test
     with tempfile.NamedTemporaryFile(suffix='.py', delete=False, mode='w') as f:
@@ -431,7 +412,7 @@ import glob
 os.environ["RESOLVE_SCRIPT_API"] = r"{api_path}"
 os.environ["RESOLVE_SCRIPT_LIB"] = r"{lib_path}"
 
-# Add ONLY the specific module path to sys.path
+# Add all possible module paths to sys.path
 search_paths = {search_paths!r}
 for path in search_paths:
     if path and path not in sys.path:
@@ -446,14 +427,55 @@ for module_file in module_files:
 # Print sys.path for debugging
 print(f"Python sys.path: {{sys.path}}")
 
-# Try direct import only - no fallbacks
+# Try direct import first
 try:
     import DaVinciResolveScript
     print("Successfully imported DaVinciResolveScript in test process")
     sys.exit(0)
 except ImportError as e:
-    print(f"Import failed: {{e}}")
-    sys.exit(1)
+    print(f"Standard import failed: {{e}}")
+
+# Try alternate import approaches
+for module_file in module_files:
+    module_dir = os.path.dirname(module_file)
+    module_name = os.path.splitext(os.path.basename(module_file))[0]
+    
+    try:
+        # Try adding module dir directly to path and importing
+        if module_dir not in sys.path:
+            sys.path.append(module_dir)
+            print(f"Added module directory {{module_dir}} directly to path")
+        
+        # Try to import again
+        import DaVinciResolveScript
+        print(f"Successfully imported DaVinciResolveScript after adding {{module_dir}}")
+        sys.exit(0)
+    except ImportError as e:
+        print(f"Import still failed with {{module_dir}} in path: {{e}}")
+
+# If all previous attempts failed, try more aggressive approaches
+# Try to load the module directly using importlib
+print("Trying direct module loading with importlib...")
+try:
+    import importlib.util
+    
+    for module_file in module_files:
+        try:
+            print(f"Trying to load {{module_file}} with importlib...")
+            spec = importlib.util.spec_from_file_location("DaVinciResolveScript", module_file)
+            if spec:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                print(f"Successfully loaded {{module_file}} with importlib")
+                sys.path.insert(0, os.path.dirname(module_file))
+                sys.exit(0)
+        except Exception as e:
+            print(f"Importlib loading failed for {{module_file}}: {{e}}")
+except Exception as e:
+    print(f"Importlib approach failed: {{e}}")
+
+print("All import attempts failed")
+sys.exit(1)
 ''')
         
     try:

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -17,7 +17,8 @@ import csv
 logging.basicConfig(level=logging.INFO)
 
 def find_module_locations(base_path):
-    """Find all possible locations of DaVinciResolveScript.py based on a base path."""
+    """Find possible locations of DaVinciResolveScript.py based on a base path.
+    Only checks the standard location and directly in the specified path."""
     locations = []
     module_paths = []
     
@@ -32,14 +33,7 @@ def find_module_locations(base_path):
     if os.path.isfile(direct_location):
         locations.append(base_path)
         module_paths.append(direct_location)
-        
-    # Check parent directory (parent_of_base_path/DaVinciResolveScript.py)
-    parent_path = os.path.dirname(base_path)
-    parent_location = os.path.join(parent_path, "DaVinciResolveScript.py")
-    if os.path.isfile(parent_location):
-        locations.append(parent_path)
-        module_paths.append(parent_location)
-        
+    
     return {
         "locations": locations,  # Directories containing the module
         "module_paths": module_paths  # Full paths to the module files

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -18,30 +18,26 @@ logging.basicConfig(level=logging.INFO)
 
 def find_module_locations(base_path):
     """Find DaVinciResolveScript.py based on a base path.
-    Only checks the exact path specified - either the file itself or the standard Modules subdirectory."""
+    ONLY checks the exact path specified - either exactly at base_path/DaVinciResolveScript.py
+    or exactly at base_path/Modules/DaVinciResolveScript.py."""
     locations = []
     module_paths = []
     
-    # If base_path is a file path that ends with DaVinciResolveScript.py
-    if os.path.isfile(base_path) and os.path.basename(base_path) == "DaVinciResolveScript.py":
-        locations.append(os.path.dirname(base_path))
-        module_paths.append(base_path)
-        return {
-            "locations": locations,
-            "module_paths": module_paths
-        }
+    # Only check these two specific locations and nowhere else
     
     # Check standard location (base_path/Modules/DaVinciResolveScript.py)
     standard_location = os.path.join(base_path, "Modules", "DaVinciResolveScript.py")
     if os.path.isfile(standard_location):
         locations.append(os.path.dirname(standard_location))
         module_paths.append(standard_location)
+        print(f"Found module at standard location: {standard_location}")
     
     # Check directly in base path (base_path/DaVinciResolveScript.py)
     direct_location = os.path.join(base_path, "DaVinciResolveScript.py")
     if os.path.isfile(direct_location):
         locations.append(base_path)
         module_paths.append(direct_location)
+        print(f"Found module directly in specified path: {direct_location}")
     
     return {
         "locations": locations,  # Directories containing the module
@@ -172,12 +168,12 @@ def validate_resolve_paths():
                     # User provided the actual file path
                     module_dir = os.path.dirname(custom_path)
                     if os.path.basename(custom_path) == "DaVinciResolveScript.py":
-                        # Set the directory as API path
+                        # Set the directory containing the file as API path
                         os.environ["RESOLVE_SCRIPT_API"] = module_dir
                         api_path = module_dir
                         config["RESOLVE_SCRIPT_API"] = module_dir
                         modified = True
-                        print(f"Set API path to: {module_dir} (based on file: {custom_path})")
+                        print(f"Set API path to directory containing file: {module_dir}")
                     else:
                         print(f"Warning: The specified file does not appear to be DaVinciResolveScript.py")
                         retry = input("Use this path anyway? (y/n): ")
@@ -240,7 +236,7 @@ def validate_resolve_paths():
                         api_path = module_dir
                         config["RESOLVE_SCRIPT_API"] = module_dir
                         modified = True
-                        print(f"Set API path to: {module_dir} (based on file: {custom_path})")
+                        print(f"Set API path to directory containing file: {module_dir}")
                         break
                     else:
                         print(f"Warning: The specified file does not appear to be DaVinciResolveScript.py")

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -23,7 +23,11 @@ def find_module_locations(base_path):
     locations = []
     module_paths = []
     
-    # Only check these two specific locations and nowhere else
+    # Debug output
+    print(f"\nChecking for module in ONLY these specific locations:")
+    print(f"  1. {os.path.join(base_path, 'Modules', 'DaVinciResolveScript.py')}")
+    print(f"  2. {os.path.join(base_path, 'DaVinciResolveScript.py')}")
+    print(f"  No other locations will be checked.")
     
     # Check standard location (base_path/Modules/DaVinciResolveScript.py)
     standard_location = os.path.join(base_path, "Modules", "DaVinciResolveScript.py")
@@ -38,6 +42,10 @@ def find_module_locations(base_path):
         locations.append(base_path)
         module_paths.append(direct_location)
         print(f"Found module directly in specified path: {direct_location}")
+    
+    # Debug output
+    if not module_paths:
+        print("Module NOT found in either location")
     
     return {
         "locations": locations,  # Directories containing the module
@@ -349,17 +357,13 @@ def validate_resolve_paths():
     logging.info(f"Using RESOLVE_SCRIPT_API: {api_path}")
     logging.info(f"Using RESOLVE_SCRIPT_LIB: {lib_path}")
     
-    # Add all module locations to sys.path
+    # Add ONLY the module locations returned by find_module_locations to sys.path
     module_info = find_module_locations(api_path)
+    logging.info("Adding ONLY these directories to Python path:")
     for path in module_info["locations"]:
         if path not in sys.path:
             sys.path.append(path)
             logging.info(f"Added to Python path: {path}")
-            
-    # Also add the API path itself if not already added
-    if api_path and api_path not in sys.path and os.path.exists(api_path):
-        sys.path.append(api_path)
-        logging.info(f"Added API path to Python path: {api_path}")
     
     logging.info("=============================================")
     
@@ -385,22 +389,18 @@ def test_resolve_import_in_subprocess():
     api_path = os.environ.get("RESOLVE_SCRIPT_API", "")
     lib_path = os.environ.get("RESOLVE_SCRIPT_LIB", "")
     
-    # Find all possible module locations
+    # Find all possible module locations - ONLY using the strict find_module_locations function
     module_info = find_module_locations(api_path)
     module_locations = module_info["locations"]
     module_files = module_info["module_paths"]
     
     # Print found paths for debugging
-    print("Found module locations:")
+    print("Found module locations for testing:")
     for path in module_files:
         print(f"  - {path}")
     
-    # Add the API path itself to search paths
+    # ONLY use the paths returned by find_module_locations
     search_paths = []
-    if os.path.exists(api_path):
-        search_paths.append(api_path)
-    
-    # Add module locations to search paths
     for loc in module_locations:
         if loc not in search_paths and os.path.exists(loc):
             search_paths.append(loc)
@@ -421,7 +421,7 @@ import glob
 os.environ["RESOLVE_SCRIPT_API"] = r"{api_path}"
 os.environ["RESOLVE_SCRIPT_LIB"] = r"{lib_path}"
 
-# Add all possible module paths to sys.path
+# Add ONLY the specific module paths to sys.path
 search_paths = {search_paths!r}
 for path in search_paths:
     if path and path not in sys.path:

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -51,8 +51,9 @@ def validate_resolve_paths():
     else:
         default_lib_path = ""
     
-    # First check if default paths exist
-    default_api_valid = os.path.isdir(default_api_path)
+    # Check if default module file exists
+    default_module_file = os.path.join(default_api_path, "Modules", "DaVinciResolveScript.py")
+    default_api_valid = os.path.isdir(default_api_path) and os.path.exists(default_module_file)
     default_lib_valid = os.path.isfile(default_lib_path)
     
     # Set API path
@@ -63,13 +64,15 @@ def validate_resolve_paths():
         # Use default path
         os.environ["RESOLVE_SCRIPT_API"] = default_api_path
     
-    # Check if API path exists
+    # Check if API path exists and module file exists
     api_path = os.environ.get("RESOLVE_SCRIPT_API", "")
-    if not os.path.isdir(api_path):
-        # Path doesn't exist, check if default path exists
+    module_file = os.path.join(api_path, "Modules", "DaVinciResolveScript.py")
+    
+    if not os.path.isdir(api_path) or not os.path.exists(module_file):
+        # Path or module doesn't exist, check if default path has the module
         if default_api_valid:
-            print(f"\nCustom DaVinci Resolve API path not found: {api_path}")
-            print(f"Default path exists: {default_api_path}")
+            print(f"\nDaVinci Resolve module not found at: {module_file}")
+            print(f"Default module exists at: {default_module_file}")
             use_default = input(f"Press Enter to use default path, or type a custom path: ")
             if not use_default.strip():
                 os.environ["RESOLVE_SCRIPT_API"] = default_api_path
@@ -78,26 +81,28 @@ def validate_resolve_paths():
                     modified = True
             else:
                 custom_path = use_default
-                if os.path.isdir(custom_path):
+                custom_module_file = os.path.join(custom_path, "Modules", "DaVinciResolveScript.py")
+                if os.path.isdir(custom_path) and os.path.exists(custom_module_file):
                     os.environ["RESOLVE_SCRIPT_API"] = custom_path
                     config["RESOLVE_SCRIPT_API"] = custom_path
                     modified = True
                 else:
-                    print(f"Warning: Path '{custom_path}' does not exist, using default path")
+                    print(f"Warning: Module not found at '{custom_path}', using default path")
                     os.environ["RESOLVE_SCRIPT_API"] = default_api_path
                     if "RESOLVE_SCRIPT_API" in config:
                         del config["RESOLVE_SCRIPT_API"]
                         modified = True
         else:
-            print(f"\nDaVinci Resolve API path not found: {api_path}")
-            print("Default path also not found. Please provide a valid path.")
+            print(f"\nDaVinci Resolve module not found at: {module_file}")
+            print("Default module also not found. Please provide a valid path.")
             custom_path = input(f"Enter path to DaVinci Resolve Scripting folder: ")
-            if os.path.isdir(custom_path):
+            custom_module_file = os.path.join(custom_path, "Modules", "DaVinciResolveScript.py")
+            if os.path.isdir(custom_path) and os.path.exists(custom_module_file):
                 os.environ["RESOLVE_SCRIPT_API"] = custom_path
                 config["RESOLVE_SCRIPT_API"] = custom_path
                 modified = True
             else:
-                print(f"Warning: Path '{custom_path}' does not exist, using default path anyway")
+                print(f"Warning: Module not found at '{custom_path}', using provided path anyway")
     
     # Set LIB path
     if "RESOLVE_SCRIPT_LIB" in config:

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -207,10 +207,10 @@ def validate_resolve_paths():
         else:
             # Default doesn't exist either - keep asking until they provide a valid path
             print(f"Default module file not found at standard locations")
-            print("Please provide a valid path to DaVinciResolveScript.py or its parent directory")
+            print("Please provide a valid path to DaVinciResolveScript.py or the directory containing it")
             
             while True:
-                custom_path = input("Enter path to DaVinciResolveScript.py or its parent directory: ")
+                custom_path = input("Enter path to DaVinciResolveScript.py or its containing directory: ")
                 if not custom_path.strip():
                     print("Error: A path must be provided.")
                     continue
@@ -384,13 +384,11 @@ def test_resolve_import_in_subprocess():
     for path in module_files:
         print(f"  - {path}")
     
-    # Add the API path itself and its parent to search paths
+    # Add the API path itself to search paths
     search_paths = []
     if os.path.exists(api_path):
         search_paths.append(api_path)
-    if os.path.exists(os.path.dirname(api_path)):
-        search_paths.append(os.path.dirname(api_path))
-        
+    
     # Add module locations to search paths
     for loc in module_locations:
         if loc not in search_paths and os.path.exists(loc):
@@ -452,27 +450,6 @@ for module_file in module_files:
         sys.exit(0)
     except ImportError as e:
         print(f"Import still failed with {{module_dir}} in path: {{e}}")
-
-# If all previous attempts failed, try more aggressive approaches
-# Try to load the module directly using importlib
-print("Trying direct module loading with importlib...")
-try:
-    import importlib.util
-    
-    for module_file in module_files:
-        try:
-            print(f"Trying to load {{module_file}} with importlib...")
-            spec = importlib.util.spec_from_file_location("DaVinciResolveScript", module_file)
-            if spec:
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                print(f"Successfully loaded {{module_file}} with importlib")
-                sys.path.insert(0, os.path.dirname(module_file))
-                sys.exit(0)
-        except Exception as e:
-            print(f"Importlib loading failed for {{module_file}}: {{e}}")
-except Exception as e:
-    print(f"Importlib approach failed: {{e}}")
 
 print("All import attempts failed")
 sys.exit(1)

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -16,9 +16,24 @@ logging.basicConfig(level=logging.INFO)
 
 # Set Resolve environment variables if not set
 if not os.getenv("RESOLVE_SCRIPT_API"):
-    os.environ["RESOLVE_SCRIPT_API"] = r"C:\ProgramData\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting"
+    # Set default paths based on OS
+    if sys.platform.startswith("win"):  # Windows
+        os.environ["RESOLVE_SCRIPT_API"] = r"C:\ProgramData\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting"
+    elif sys.platform == "darwin":  # macOS
+        os.environ["RESOLVE_SCRIPT_API"] = r"/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting"
+    elif sys.platform.startswith("linux"):  # Linux
+        os.environ["RESOLVE_SCRIPT_API"] = r"/opt/resolve/Developer/Scripting"
+    logging.info(f"Set RESOLVE_SCRIPT_API to {os.environ['RESOLVE_SCRIPT_API']}")
+
 if not os.getenv("RESOLVE_SCRIPT_LIB"):
-    os.environ["RESOLVE_SCRIPT_LIB"] = r"C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll"
+    # Set default paths based on OS
+    if sys.platform.startswith("win"):  # Windows
+        os.environ["RESOLVE_SCRIPT_LIB"] = r"C:\Program Files\Blackmagic Design\DaVinci Resolve\fusionscript.dll"
+    elif sys.platform == "darwin":  # macOS
+        os.environ["RESOLVE_SCRIPT_LIB"] = r"/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion/fusionscript.so"
+    elif sys.platform.startswith("linux"):  # Linux
+        os.environ["RESOLVE_SCRIPT_LIB"] = r"/opt/resolve/libs/Fusion/fusionscript.so"
+    logging.info(f"Set RESOLVE_SCRIPT_LIB to {os.environ['RESOLVE_SCRIPT_LIB']}")
 
 # Add Resolve scripting module path
 resolve_script_path = os.path.join(os.environ.get('RESOLVE_SCRIPT_API', ''), 'Modules')


### PR DESCRIPTION
Added better support to handle environment variables so the user doesn't have to define them if they are the standard default. If the user has different environment variables, the program should detect that and let the user specify what their custom variables are. It should save the preferences in the same directory as the script.

**Notes:**
- If the script is being run globally via an alias to this project, if there are custom environment variables, they might not be properly read due to the location of running the python script. This is untested and could be a potential issue, only if an environment variable is custom. Others could submit a pull request if this is an issue and they have a workaround. Otherwise, the default path could be modified for the user manually and the this won't be an issue
- I wasted a lot of time trying to define custom paths, getting hung up on a test I did, which was a poorly chosen example and it took me a while to realize that. See commit history if you want my journey on those struggles.