### PR TITLE
Fix/export timing issues

### DIFF
--- a/generate_srt.py
+++ b/generate_srt.py
@@ -1078,6 +1078,10 @@ def get_subtitle_items(timeline):
             
         logging.info(f"Found {len(items)} items in subtitle track")
         
+        # Get timeline start frame to offset subtitles to start at 00:00:00,000
+        timeline_start_frame = timeline.GetStartFrame()
+        logging.info(f"Timeline start frame: {timeline_start_frame}")
+        
         # Extract text and timing from items
         subtitle_items = []
         for i, item in enumerate(items):
@@ -1085,10 +1089,15 @@ def get_subtitle_items(timeline):
             logging.info(f"Raw text from Resolve (item {i}): {repr(text)}")  # Use repr to show special characters
             start = item.GetStart()
             end = item.GetEnd()
+            
+            # Offset by timeline start frame so subtitles start at 00:00:00,000
+            start_offset = start - timeline_start_frame
+            end_offset = end - timeline_start_frame
+            
             subtitle_items.append({
                 'text': text,
-                'start': start,
-                'end': end,
+                'start': start_offset,
+                'end': end_offset,
                 'index': i + 1
             })
             logging.info(f"Found text in item {i}: {text}")


### PR DESCRIPTION
Exporting glitch fixes. Fixed the following:
- If the timeline framerate is different than 24 FPS, will now be properly synced for any timeline framerate, unlike before.
- If the starting timecode is not 00:00:00:00 (Resolve does 01:00:00:00 by default), the transcript would offset. Now, it will factor in the offset properly in the final output. If it seems like subtitles didn't work, this was why. It may have been an hour off