### PR TITLE
Feature/temp audio conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resolve Subtitle Generator
 
-A Python script that generates SRT subtitle files from audio files using DaVinci Resolve's auto-captioning feature.
+A Python script that generates SRT subtitle files from audio and video files using DaVinci Resolve's auto-captioning feature.
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@ A Python script that generates SRT subtitle files from audio files using DaVinci
 ## Usage
 
 1. **Start DaVinci Resolve** and create a new project or open an existing one. It won't work without Resolve running as it still uses the UI for functionality, but still fortunately in an automated way.
-2. **Run the script** with one or more audio files as arguments:
+2. **Run the script** with one or more audio or video files as arguments:
 
 ```bash
 # Process a single file
@@ -20,29 +20,30 @@ python generate_srt.py "path/to/your/audio.mp3"
 # Process multiple files
 python generate_srt.py "audio1.mp3" "audio2.mp3" "audio3.mp3"
 
-# Process all MP3 files in a directory
-python generate_srt.py "samples/*.MP3"
+# Process all M4A files in a directory
+python generate_srt.py "samples/*.m4a"
 ```
 
 The script will:
-1. Create a timeline for each audio file
+1. Create a timeline for each file
 2. Generate subtitles using Resolve's auto-captioning
 3. Export the subtitles as SRT files in the same directory as the input files
 
 ## Output
 
-For each input audio file, a corresponding SRT file will be created in the same directory with the same name (but with .srt extension). For example:
+For each input file, a corresponding SRT file will be created in the same directory as the original source with the same name (but with `.srt` extension). For example:
 - Input: `samples/audio1.mp3`
 - Output: `samples/audio1.srt`
+
+This holds even when using conversion flags — the SRT is always saved next to the original, not the converted temp file.
 
 ## Notes
 
 - To minimize current random glitches that exist (see [issues](https://github.com/zinsy23/resolve-subtitle-generator/issues)), let the script itself import the media rather than yourself and have the master bin selected
 - The script requires DaVinci Resolve to be running and a project to be open
 - The script will create timelines in the current project
-- Audio files should be in a format supported by DaVinci Resolve (MP3, WAV, etc.)
 - The generated SRT files include bold formatting and proper line breaks
-- The version of my script does my typical preferred settings, so you may consider modifying the `create_subtitles_from_audio()` function in generate_srt.py to match your settings. 
+- The version of my script does my typical preferred settings, so you may consider modifying the `create_subtitles_from_audio()` function in generate_srt.py to match your settings.
     - I haven't tested single line SRT creation yet since it has linebreak logic in it for double lines
 - I generated this program using AI until it did my desired behavior, so please excuse any brevity in this project since I'm more concerned about being able to use it as a tool for myself.
 
@@ -116,6 +117,60 @@ Here's how I recommend you execute the script from any directory:
 
    d. Close and reopen the terminal to apply the changes. It should work anywhere now. You can restart bash by running `exec bash` in the bash shell.
    
+## Audio/Video Conversion
+
+If Resolve doesn't support the audio codec in your file (e.g. AAC in an M4A on Linux), you can convert it on the fly before importing using a `--<format>` flag. The converted file is temporary and the SRT is always saved next to the original source file.
+
+```bash
+# Convert a single M4A to WAV before importing
+python generate_srt.py "episode.m4a" --wav
+
+# Convert to a specific directory instead of temp
+python generate_srt.py "episode.m4a" --wav "/path/to/output"
+
+# Convert all M4A files to MP3 before importing
+python generate_srt.py "samples/*.m4a" --mp3
+
+# Mix converted and non-converted files in one command
+python generate_srt.py "episode1.m4a" --wav "episode2.wav" "episode3.m4a" --mp3
+
+# Convert audio track in a video file (video stream is preserved, only audio is transcoded)
+python generate_srt.py "recording.mp4" --mp3
+```
+
+### Supported conversion formats
+
+| Flag | Format |
+|------|--------|
+| `--mp3` | MP3 |
+| `--wav` | WAV |
+| `--aac` | AAC |
+| `--flac` | FLAC |
+| `--opus` | Opus |
+| `--ogg` | OGG Vorbis |
+| `--aiff` | AIFF |
+
+### Video container compatibility
+
+For video files, only the audio stream is transcoded — the video is copied as-is. Not all audio formats work in every container:
+
+| Container | Supported audio formats |
+|-----------|------------------------|
+| `.mp4` | `--mp3`, `--aac`, `--opus`, `--wav` |
+| `.mov` | `--mp3`, `--aac`, `--wav` |
+| `.mkv` | `--mp3`, `--aac`, `--wav`, `--flac`, `--opus` |
+| `.avi` | `--mp3`, `--aac` |
+
+Unsupported combinations are rejected with a clear error message listing what's allowed.
+
+### ffmpeg Setup
+
+ffmpeg is required for conversion flags. If it's not installed, the script will print an error. Install it using one of the following (these are common methods, not exhaustive):
+
+- **Linux:** `sudo apt install ffmpeg` (or your distro's package manager equivalent)
+- **macOS:** `brew install ffmpeg` (or https://ffmpeg.org/download.html)
+- **Windows:** `winget install ffmpeg` (or https://ffmpeg.org/download.html)
+
 ## Troubleshooting
 
 If you encounter issues:
@@ -184,37 +239,29 @@ If you encounter issues installing PyAudio on macOS, try the following steps:
    
    Also make sure your environment variables are set properly for the specific Python version you're using.
 
-### PyDub/AudioOp Issues on macOS with Python 3.13
+### PyDub/AudioOp Issues on Python 3.13
 
-If you're using Python 3.13 on macOS and encounter errors related to `audioop`, `_audioop`, or `pyaudioop` when importing PyDub, this is a known compatibility issue. Run the provided global Python fix script:
+Python 3.13 removed the `audioop` module from the standard library, which PyDub depends on. This affects all platforms. Run the provided fix script:
 
 ```bash
-./global_python_fix.py
+python3 global_python_fix.py
 ```
 
-This script:
-1. Reinstalls PyDub with the system Python 3.13
-2. Creates compatibility modules (`_audioop.py`, `audioop.py`, and `pyaudioop.py`)
-3. Tests that PyDub can be imported and used
+**What the script does per platform:**
 
-The fix works by creating dummy implementations of the audio processing modules that PyDub expects but are missing or renamed in Python 3.13.
-
-**After running the fix:**
-- Use the global Python 3.13 interpreter to run your scripts:
-  ```bash
-  /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13 generate_srt.py "your_audio_file.mp3"
-  ```
-- Make sure to use the full path to the Python 3.13 interpreter rather than relying on environment variables or aliases
+- **Linux** — installs `audioop-lts` (a maintained backport of `audioop` for Python 3.13+) via pip. You will be prompted before it runs `--break-system-packages`, which installs to your user packages (`~/.local/lib/...`) and is safe. If you prefer a virtual environment instead, the script will print guidance for that.
+- **macOS** — reinstalls PyDub and creates compatibility shim modules for `audioop`.
+- **Windows** — same as macOS.
 
 **Known errors this fixes:**
 ```
 ModuleNotFoundError: No module named 'audioop'
-```
-or
-```
 ModuleNotFoundError: No module named 'pyaudioop'
 ```
 
-**Note:** The fix adds dummy implementations of the audio operations modules, which should be sufficient for basic PyDub functionality but may not work for all advanced audio processing operations.
+If you'd prefer to fix it manually on Linux without the script:
+```bash
+pip install --user --break-system-packages audioop-lts
+```
 
-If you still encounter issues after running the fix script, consider downgrading to Python 3.9 which has better compatibility with audio processing libraries.
+If you still encounter issues after running the fix script, consider using a virtual environment with Python 3.11 or 3.12 which still include `audioop` natively.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python generate_srt.py "samples/*.m4a" --mp3
 # Mix converted and non-converted files in one command
 python generate_srt.py "episode1.m4a" --wav "episode2.wav" "episode3.m4a" --mp3
 
-# Convert audio track in a video file (video stream is preserved, only audio is transcoded)
+# Convert audio track in a video file (e.g. AAC in MP4 unsupported on Linux — video stream is preserved, only audio is transcoded)
 python generate_srt.py "recording.mp4" --mp3
 ```
 
@@ -170,6 +170,55 @@ ffmpeg is required for conversion flags. If it's not installed, the script will 
 - **Linux:** `sudo apt install ffmpeg` (or your distro's package manager equivalent)
 - **macOS:** `brew install ffmpeg` (or https://ffmpeg.org/download.html)
 - **Windows:** `winget install ffmpeg` (or https://ffmpeg.org/download.html)
+
+### Setting a default conversion output directory
+
+By default, converted files go to the system temp directory and are cleaned up on reboot. To always save conversions to a specific location instead, set a preference:
+
+```bash
+# Set a default conversion output directory (all aliases do the same thing)
+python generate_srt.py --conv-dir "/my/output/path"
+python generate_srt.py --conversion-dir "/my/output/path"
+python generate_srt.py --set-conv-dir "/my/output/path"
+python generate_srt.py --set-conversion-dir "/my/output/path"
+python generate_srt.py --temp-dir "/my/output/path"
+python generate_srt.py --tmp-dir "/my/output/path"
+
+# Reset back to system temp
+python generate_srt.py --conv-dir clear
+python generate_srt.py --conv-dir temp
+```
+
+Once set, all conversions save to that directory automatically — no need to specify a path per-file. A per-file explicit path (e.g. `"episode.m4a" --wav "/some/path"`) still overrides the preference for that call. The preference is stored in `preferences.json` next to the script and only created when a non-default value is set. Relative paths are resolved to absolute at set time so the preference works correctly regardless of where you run the command from.
+
+## Global Flags
+
+These flags apply to the whole command rather than individual files and can be placed anywhere in the argument list.
+
+| Flag | Description |
+|------|-------------|
+| `--concat` | Import all files into a single timeline instead of separate ones. Subtitles are generated across the entire timeline. Does not export an SRT by default — use with `--export` to save one. |
+| `--export` | Write the SRT file. Redundant for normal per-file use (always exports), but required to export when using `--concat`. |
+| `--import` | Import files into Resolve without generating subtitles. Works with and without `--concat`. Useful when you just need the conversion and import, not the subtitles. |
+
+### Examples
+
+```bash
+# Import all M4A files into one timeline, generate subtitles in Resolve only (no SRT file)
+python generate_srt.py "*.m4a" --wav --concat
+
+# Same but also export the SRT next to the first file
+python generate_srt.py "*.m4a" --wav --concat --export
+
+# Generate subtitles in Resolve for a single file without exporting an SRT
+python generate_srt.py "episode.m4a" --concat
+
+# Convert AAC audio in an MP4 to MP3 and import into Resolve without generating subtitles
+python generate_srt.py "recording.mp4" --mp3 --import
+
+# Same but for multiple MP4s, all into one timeline
+python generate_srt.py "*.mp4" --mp3 --import --concat
+```
 
 ## Troubleshooting
 

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import glob
+import shutil
 import time
 import ctypes
 from ctypes import wintypes
@@ -15,6 +16,10 @@ import csv
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
+
+# Supported conversion formats for the --<fmt> flags.
+# To add a new format, add it here — flags and usage messages are derived from this.
+SUPPORTED_CONVERSION_FORMATS = {"wav", "mp3", "flac", "aac", "ogg", "opus", "aiff"}
 
 def find_module_locations(base_path):
     """Find possible locations of DaVinciResolveScript.py based on a base path.
@@ -671,6 +676,111 @@ def expand_file_args(args):
         else:
             expanded_files.append(arg)
     return expanded_files
+
+def check_ffmpeg():
+    """Return True if ffmpeg is available on PATH."""
+    return shutil.which("ffmpeg") is not None
+
+def convert_audio(source_path, fmt, output_dir=None):
+    """Convert source_path to the given format extension via ffmpeg.
+
+    fmt is any extension ffmpeg supports (e.g. 'wav', 'mp3', 'flac').
+    If output_dir is None the OS temp directory is used.
+    Appends _1, _2, … to the stem if the destination already exists.
+    Returns the output path on success, or "FAILED" on error.
+    """
+    if not check_ffmpeg():
+        print("Error: ffmpeg was not found on your PATH.")
+        print("Install it using one of the following (these are common methods, not exhaustive):")
+        print("  Linux:   sudo apt install ffmpeg  (or your distro's package manager equivalent)")
+        print("  macOS:   brew install ffmpeg  (or https://ffmpeg.org/download.html)")
+        print("  Windows: winget install ffmpeg  (or https://ffmpeg.org/download.html)")
+        supported = ", ".join(f"--{fmt}" for fmt in sorted(SUPPORTED_CONVERSION_FORMATS))
+        print(f"Supported conversion flags: {supported}")
+        return "FAILED"
+
+    stem = os.path.splitext(os.path.basename(source_path))[0]
+    dest_dir = output_dir if output_dir else tempfile.gettempdir()
+    os.makedirs(dest_dir, exist_ok=True)
+
+    candidate = os.path.join(dest_dir, f"{stem}.{fmt}")
+    counter = 1
+    while os.path.exists(candidate):
+        candidate = os.path.join(dest_dir, f"{stem}_{counter}.{fmt}")
+        counter += 1
+
+    result = subprocess.run(
+        ["ffmpeg", "-i", source_path, candidate],
+        capture_output=True,
+        text=True
+    )
+    if result.returncode != 0:
+        logging.error(f"ffmpeg conversion failed: {result.stderr}")
+        print(f"Error: ffmpeg failed to convert {os.path.basename(source_path)}")
+        return "FAILED"
+
+    logging.info(f"Converted {source_path} -> {candidate}")
+    return candidate
+
+
+def parse_args(argv):
+    """Parse argv into a list of (source_path, converted_path_or_None) tuples.
+
+    Syntax per entry:
+        <file> [--<fmt> [dest_dir]]
+
+    --<fmt> can be any format ffmpeg supports (e.g. --wav, --mp3, --flac).
+    The optional dest_dir after the flag is consumed if the next token doesn't
+    look like an audio source file. Wildcards in file arguments are expanded.
+    """
+    AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma", ".aiff"}
+    CONVERT_FLAGS = {f"--{fmt}" for fmt in SUPPORTED_CONVERSION_FORMATS}
+
+    def is_convert_flag(token):
+        """Return the format string if token is a supported --<fmt> flag, else None."""
+        return token[2:] if token in CONVERT_FLAGS else None
+
+    entries = []
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+
+        # If we hit a bare flag with no preceding file, skip it
+        if is_convert_flag(token):
+            i += 1
+            continue
+
+        # Expand wildcards for this source token
+        if '*' in token or '?' in token:
+            sources = sorted(glob.glob(token))
+        else:
+            sources = [token]
+
+        i += 1
+
+        # Check for an optional conversion flag immediately after
+        fmt = None
+        output_dir = None
+        if i < len(argv):
+            fmt = is_convert_flag(argv[i])
+            if fmt:
+                i += 1
+                # Check for an optional output directory after the flag
+                if i < len(argv):
+                    next_token = argv[i]
+                    ext = os.path.splitext(next_token)[1].lower()
+                    if not next_token.startswith('-') and ext not in AUDIO_EXTENSIONS:
+                        output_dir = next_token
+                        i += 1
+
+        for source in sources:
+            if fmt:
+                converted = convert_audio(source, fmt, output_dir)
+                entries.append((source, converted))
+            else:
+                entries.append((source, None))
+
+    return entries
 
 def get_audio_duration(audio_file):
     """Get the duration of an audio file in seconds."""
@@ -1388,40 +1498,51 @@ def clear_subtitle_tracks(timeline):
 def main():
     # Get files to process
     if len(sys.argv) > 1:
-        # Process files provided as arguments
-        files_to_process = []
-        for arg in sys.argv[1:]:
-            if '*' in arg or '?' in arg:
-                # Expand wildcards
-                files_to_process.extend(glob.glob(arg))
-            else:
-                files_to_process.append(arg)
+        entries = parse_args(sys.argv[1:])
     else:
         # Process all MP3 files in samples directory
         samples_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "samples")
-        files_to_process = [os.path.join(samples_dir, f) for f in os.listdir(samples_dir) if f.endswith('.MP3')]
-    
-    if not files_to_process:
+        entries = [
+            (os.path.join(samples_dir, f), None)
+            for f in os.listdir(samples_dir) if f.endswith('.MP3')
+        ]
+
+    if not entries:
         print("No files to process")
         return
-    
+
+    # Drop entries where conversion failed or source not found
+    valid_entries = []
+    for src, conv in entries:
+        if conv is None and not os.path.exists(src):
+            print(f"File not found, skipping: {src}")
+            continue
+        if conv == "FAILED":
+            # convert_audio failed; error already printed
+            continue
+        valid_entries.append((src, conv))
+
+    if not valid_entries:
+        print("No valid files to process")
+        return
+
     # Get initial Resolve setup
     try:
         resolve = get_resolve()
         if not resolve:
             print("Failed to get Resolve object")
             return
-            
+
         project = get_current_project()
         if not project:
             print("No project is currently open. Please open a project first.")
             return
-            
+
         media_pool = project.GetMediaPool()
         if not media_pool:
             print("Failed to get media pool")
             return
-            
+
         root_folder = media_pool.GetRootFolder()
         if not root_folder:
             print("Failed to get root folder")
@@ -1429,25 +1550,27 @@ def main():
     except Exception as e:
         print(f"Error setting up Resolve: {str(e)}")
         return
-    
+
     # Process each file sequentially
     successful = 0
-    for file_path in files_to_process:
+    for src, conv in valid_entries:
+        import_path = conv if conv else src
         try:
-            print(f"\nProcessing {os.path.basename(file_path)}...")
-            
-            # Generate SRT
-            if generate_srt_for_file(file_path):
+            print(f"\nProcessing {os.path.basename(src)}...")
+            if conv:
+                print(f"  Using converted file: {conv}")
+
+            if generate_srt_for_file(import_path):
                 successful += 1
-                print(f"Successfully generated SRT for {os.path.basename(file_path)}")
+                print(f"Successfully generated SRT for {os.path.basename(src)}")
             else:
-                print(f"Failed to generate SRT for {os.path.basename(file_path)}")
-                
+                print(f"Failed to generate SRT for {os.path.basename(src)}")
+
         except Exception as e:
-            print(f"Error processing {os.path.basename(file_path)}: {str(e)}")
+            print(f"Error processing {os.path.basename(src)}: {str(e)}")
             continue
-    
-    print(f"\nProcessed {len(files_to_process)} file(s), {successful} successful")
+
+    print(f"\nProcessed {len(valid_entries)} file(s), {successful} successful")
 
 if __name__ == "__main__":
     main() 

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -1689,7 +1689,7 @@ def main():
         samples_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "samples")
         entries = [
             (os.path.join(samples_dir, f), None)
-            for f in os.listdir(samples_dir) if f.endswith('.MP3')
+            for f in os.listdir(samples_dir) if f.lower().endswith('.mp3')
         ]
         do_concat = False
         do_export = False

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -740,38 +740,47 @@ def parse_args(argv):
         """Return the format string if token is a supported --<fmt> flag, else None."""
         return token[2:] if token in CONVERT_FLAGS else None
 
+    def peek_flag(argv, i):
+        """Return (fmt, output_dir, new_i) if argv[i] is a conversion flag, else (None, None, i)."""
+        if i >= len(argv):
+            return None, None, i
+        fmt = is_convert_flag(argv[i])
+        if not fmt:
+            return None, None, i
+        i += 1
+        output_dir = None
+        if i < len(argv):
+            next_token = argv[i]
+            ext = os.path.splitext(next_token)[1].lower()
+            if not next_token.startswith('-') and ext not in AUDIO_EXTENSIONS:
+                output_dir = next_token
+                i += 1
+        return fmt, output_dir, i
+
     entries = []
     i = 0
     while i < len(argv):
         token = argv[i]
 
-        # If we hit a bare flag with no preceding file, skip it
+        # Skip a bare flag with no preceding file
         if is_convert_flag(token):
             i += 1
             continue
 
-        # Expand wildcards for this source token
-        if '*' in token or '?' in token:
-            sources = sorted(glob.glob(token))
-        else:
-            sources = [token]
+        # Collect a run of consecutive file tokens (no flag in between).
+        # This handles shell-expanded wildcards where the shell splits
+        # "*.m4a --wav" into individual filenames before Python sees them.
+        sources = []
+        while i < len(argv) and not is_convert_flag(argv[i]):
+            tok = argv[i]
+            if '*' in tok or '?' in tok:
+                sources.extend(sorted(glob.glob(tok)))
+            else:
+                sources.append(tok)
+            i += 1
 
-        i += 1
-
-        # Check for an optional conversion flag immediately after
-        fmt = None
-        output_dir = None
-        if i < len(argv):
-            fmt = is_convert_flag(argv[i])
-            if fmt:
-                i += 1
-                # Check for an optional output directory after the flag
-                if i < len(argv):
-                    next_token = argv[i]
-                    ext = os.path.splitext(next_token)[1].lower()
-                    if not next_token.startswith('-') and ext not in AUDIO_EXTENSIONS:
-                        output_dir = next_token
-                        i += 1
+        # Check for an optional conversion flag after the file group
+        fmt, output_dir, i = peek_flag(argv, i)
 
         for source in sources:
             if fmt:

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -21,6 +21,27 @@ logging.basicConfig(level=logging.INFO)
 # To add a new format, add it here — flags and usage messages are derived from this.
 SUPPORTED_CONVERSION_FORMATS = {"wav", "mp3", "flac", "aac", "ogg", "opus", "aiff"}
 
+# Video container extensions and the audio formats verified to work in each.
+# For video files, only the audio stream is transcoded; video is copied as-is.
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi"}
+VIDEO_CONTAINER_AUDIO_COMPAT = {
+    ".mp4": {"mp3", "aac", "opus", "wav"},
+    ".mov": {"mp3", "aac", "wav"},
+    ".mkv": {"mp3", "aac", "wav", "flac", "opus"},
+    ".avi": {"mp3", "aac"},
+}
+
+# Maps audio format name to the ffmpeg codec to use
+AUDIO_FORMAT_CODEC = {
+    "mp3":  "libmp3lame",
+    "aac":  "aac",
+    "opus": "libopus",
+    "wav":  "pcm_s16le",
+    "flac": "flac",
+    "ogg":  "libvorbis",
+    "aiff": "pcm_s16le",
+}
+
 def find_module_locations(base_path):
     """Find possible locations of DaVinciResolveScript.py based on a base path.
     Only checks the standard location and directly in the specified path."""
@@ -682,9 +703,12 @@ def check_ffmpeg():
     return shutil.which("ffmpeg") is not None
 
 def convert_audio(source_path, fmt, output_dir=None):
-    """Convert source_path to the given format extension via ffmpeg.
+    """Convert source_path to the given format via ffmpeg.
 
-    fmt is any extension ffmpeg supports (e.g. 'wav', 'mp3', 'flac').
+    For audio-only files: transcodes to the target format.
+    For video files: copies the video stream and transcodes only the audio,
+    keeping the same container extension.
+
     If output_dir is None the OS temp directory is used.
     Appends _1, _2, … to the stem if the destination already exists.
     Returns the output path on success, or "FAILED" on error.
@@ -699,21 +723,43 @@ def convert_audio(source_path, fmt, output_dir=None):
         print(f"Supported conversion flags: {supported}")
         return "FAILED"
 
+    src_ext = os.path.splitext(source_path)[1].lower()
+    is_video = src_ext in VIDEO_EXTENSIONS
+
+    # For video files, validate the container+audio format combination
+    if is_video:
+        allowed = VIDEO_CONTAINER_AUDIO_COMPAT.get(src_ext, set())
+        if fmt not in allowed:
+            print(f"Error: '{fmt}' audio is not supported in {src_ext} containers.")
+            supported = ", ".join(f"--{f}" for f in sorted(allowed))
+            print(f"Supported formats for {src_ext}: {supported}")
+            return "FAILED"
+        # Video output keeps the same container extension
+        out_ext = src_ext
+    else:
+        out_ext = f".{fmt}"
+
+    codec = AUDIO_FORMAT_CODEC.get(fmt)
+    if not codec:
+        print(f"Error: No ffmpeg codec mapping found for format '{fmt}'.")
+        return "FAILED"
+
     stem = os.path.splitext(os.path.basename(source_path))[0]
     dest_dir = output_dir if output_dir else tempfile.gettempdir()
     os.makedirs(dest_dir, exist_ok=True)
 
-    candidate = os.path.join(dest_dir, f"{stem}.{fmt}")
+    candidate = os.path.join(dest_dir, f"{stem}{out_ext}")
     counter = 1
     while os.path.exists(candidate):
-        candidate = os.path.join(dest_dir, f"{stem}_{counter}.{fmt}")
+        candidate = os.path.join(dest_dir, f"{stem}_{counter}{out_ext}")
         counter += 1
 
-    result = subprocess.run(
-        ["ffmpeg", "-i", source_path, candidate],
-        capture_output=True,
-        text=True
-    )
+    if is_video:
+        cmd = ["ffmpeg", "-i", source_path, "-c:v", "copy", "-c:a", codec, candidate, "-y"]
+    else:
+        cmd = ["ffmpeg", "-i", source_path, "-c:a", codec, candidate, "-y"]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         logging.error(f"ffmpeg conversion failed: {result.stderr}")
         print(f"Error: ffmpeg failed to convert {os.path.basename(source_path)}")

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -1326,13 +1326,13 @@ def get_current_project():
         logging.error(f"Error getting current project: {str(e)}")
         return None
 
-def generate_srt_for_file(audio_file):
+def generate_srt_for_file(audio_file, srt_output_path=None):
     """Generate SRT file for a given audio file."""
     try:
         logging.info(f"Starting SRT generation for: {audio_file}")
-        
-        # Get output path
-        output_path = os.path.splitext(audio_file)[0] + ".srt"
+
+        # Get output path — use explicit path if provided (e.g. when audio_file is a temp conversion)
+        output_path = srt_output_path if srt_output_path else os.path.splitext(audio_file)[0] + ".srt"
         logging.info(f"Output SRT will be saved to: {output_path}")
         
         # Get Resolve object
@@ -1569,7 +1569,8 @@ def main():
             if conv:
                 print(f"  Using converted file: {conv}")
 
-            if generate_srt_for_file(import_path):
+            srt_path = os.path.splitext(src)[0] + ".srt"
+            if generate_srt_for_file(import_path, srt_output_path=srt_path):
                 successful += 1
                 print(f"Successfully generated SRT for {os.path.basename(src)}")
             else:

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -769,6 +769,22 @@ def convert_audio(source_path, fmt, output_dir=None):
     return candidate
 
 
+def ci_glob(pattern):
+    """Convert a glob pattern to a case-insensitive equivalent.
+
+    Each alphabetic character is replaced with a [aA]-style bracket expression
+    so that glob.glob matches regardless of case on case-sensitive filesystems.
+    e.g. "*.mp3" -> "*.[mM][pP][3]"  (digits pass through unchanged)
+    """
+    result = []
+    for ch in pattern:
+        if ch.isalpha():
+            result.append(f"[{ch.lower()}{ch.upper()}]")
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
 def parse_args(argv):
     """Parse argv into entries and global flags.
 
@@ -831,7 +847,7 @@ def parse_args(argv):
         while i < len(argv) and not is_convert_flag(argv[i]):
             tok = argv[i]
             if '*' in tok or '?' in tok:
-                sources.extend(sorted(glob.glob(tok)))
+                sources.extend(sorted(glob.glob(ci_glob(tok))))
             else:
                 sources.append(tok)
             i += 1

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -21,6 +21,9 @@ logging.basicConfig(level=logging.INFO)
 # To add a new format, add it here — flags and usage messages are derived from this.
 SUPPORTED_CONVERSION_FORMATS = {"wav", "mp3", "flac", "aac", "ogg", "opus", "aiff"}
 
+PREFS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "preferences.json")
+CONV_DIR_FLAGS = {"--conv-dir", "--conversion-dir", "--set-conv-dir", "--set-conversion-dir", "--temp-dir", "--tmp-dir"}
+
 # Video container extensions and the audio formats verified to work in each.
 # For video files, only the audio stream is transcoded; video is copied as-is.
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".avi"}
@@ -698,6 +701,56 @@ def expand_file_args(args):
             expanded_files.append(arg)
     return expanded_files
 
+def load_preferences():
+    """Load preferences.json, returning an empty dict if it doesn't exist."""
+    if os.path.exists(PREFS_FILE):
+        try:
+            with open(PREFS_FILE, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            logging.warning(f"Failed to load preferences: {e}")
+    return {}
+
+def save_preferences(prefs):
+    """Save preferences dict to preferences.json, deleting the file if empty."""
+    try:
+        if prefs:
+            with open(PREFS_FILE, 'w') as f:
+                json.dump(prefs, f, indent=2)
+        elif os.path.exists(PREFS_FILE):
+            os.remove(PREFS_FILE)
+    except Exception as e:
+        logging.warning(f"Failed to save preferences: {e}")
+
+def handle_conv_dir_flag(value):
+    """Set or clear the conversion_output_dir preference and exit."""
+    if not value:
+        print("Usage: --conv-dir <path>  (set conversion output directory)")
+        print("       --conv-dir clear   (reset to system temp)")
+        print("       --conv-dir temp    (reset to system temp)")
+        sys.exit(0)
+
+    prefs = load_preferences()
+    if value.lower() in ("clear", "temp"):
+        if "conversion_output_dir" in prefs:
+            del prefs["conversion_output_dir"]
+            save_preferences(prefs)
+            print("Conversion output directory reset to system temp.")
+        else:
+            print("No conversion output directory was set (already using system temp).")
+    else:
+        abs_value = os.path.abspath(value)
+        prefs["conversion_output_dir"] = abs_value
+        save_preferences(prefs)
+        print(f"Conversion output directory set to: {abs_value}")
+    sys.exit(0)
+
+def get_conversion_output_dir():
+    """Return the preferred conversion output dir, or None to use system temp."""
+    prefs = load_preferences()
+    return prefs.get("conversion_output_dir", None)
+
+
 def check_ffmpeg():
     """Return True if ffmpeg is available on PATH."""
     return shutil.which("ffmpeg") is not None
@@ -745,7 +798,7 @@ def convert_audio(source_path, fmt, output_dir=None):
         return "FAILED"
 
     stem = os.path.splitext(os.path.basename(source_path))[0]
-    dest_dir = output_dir if output_dir else tempfile.gettempdir()
+    dest_dir = output_dir if output_dir else (get_conversion_output_dir() or tempfile.gettempdir())
     os.makedirs(dest_dir, exist_ok=True)
 
     candidate = os.path.join(dest_dir, f"{stem}{out_ext}")
@@ -1619,6 +1672,14 @@ def clear_subtitle_tracks(timeline):
         return False
 
 def main():
+    # Handle conv-dir preference flags before anything else
+    argv = sys.argv[1:]
+    for flag in CONV_DIR_FLAGS:
+        if flag in argv:
+            idx = argv.index(flag)
+            value = argv[idx + 1] if idx + 1 < len(argv) else None
+            handle_conv_dir_flag(value)
+
     # Get files to process
     if len(sys.argv) > 1:
         entries, do_concat, do_export, do_import_only = parse_args(sys.argv[1:])

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -802,11 +802,12 @@ def parse_args(argv):
     """
     AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma", ".aiff"}
     CONVERT_FLAGS = {f"--{fmt}" for fmt in SUPPORTED_CONVERSION_FORMATS}
-    GLOBAL_FLAGS = {"--concat", "--export"}
+    GLOBAL_FLAGS = {"--concat", "--export", "--import"}
 
     # Strip global flags first so they don't interfere with per-file parsing
     do_concat = "--concat" in argv
     do_export = "--export" in argv
+    do_import_only = "--import" in argv
     argv = [a for a in argv if a not in GLOBAL_FLAGS]
 
     def is_convert_flag(token):
@@ -862,7 +863,7 @@ def parse_args(argv):
             else:
                 entries.append((source, None))
 
-    return entries, do_concat, do_export
+    return entries, do_concat, do_export, do_import_only
 
 def get_audio_duration(audio_file):
     """Get the duration of an audio file in seconds."""
@@ -1450,17 +1451,18 @@ def build_timeline(project, media_pool, import_paths, timeline_name):
         return None
 
 
-def generate_srt(import_paths, timeline_name, srt_output_path, do_export=True):
-    """Core pipeline: import files, build timeline, generate subtitles, optionally export SRT.
+def generate_srt(import_paths, timeline_name, srt_output_path, do_export=True, do_import_only=False):
+    """Core pipeline: import files, build timeline, optionally generate subtitles and export SRT.
 
-    import_paths   — list of file paths to import (one for normal, many for concat)
-    timeline_name  — name to give the timeline in Resolve
+    import_paths    — list of file paths to import (one for normal, many for concat)
+    timeline_name   — name to give the timeline in Resolve
     srt_output_path — where to write the SRT file (used only when do_export=True)
-    do_export      — write the SRT file when True; skip when False (concat default)
+    do_export       — write the SRT file when True; skip when False (concat default)
+    do_import_only  — stop after importing into timeline, skip subtitle generation entirely
     """
     try:
-        logging.info(f"Starting SRT generation for: {import_paths}")
-        if do_export:
+        logging.info(f"Starting {'import' if do_import_only else 'SRT generation'} for: {import_paths}")
+        if do_export and not do_import_only:
             logging.info(f"Output SRT will be saved to: {srt_output_path}")
 
         resolve = get_resolve()
@@ -1486,6 +1488,10 @@ def generate_srt(import_paths, timeline_name, srt_output_path, do_export=True):
         if not verify_project_state(project, timeline):
             logging.error("Project state verification failed")
             return False
+
+        if do_import_only:
+            logging.info("Import complete (subtitle generation skipped)")
+            return True
 
         if not clear_subtitle_tracks(timeline):
             logging.error("Failed to clear subtitle tracks")
@@ -1615,7 +1621,7 @@ def clear_subtitle_tracks(timeline):
 def main():
     # Get files to process
     if len(sys.argv) > 1:
-        entries, do_concat, do_export = parse_args(sys.argv[1:])
+        entries, do_concat, do_export, do_import_only = parse_args(sys.argv[1:])
     else:
         samples_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "samples")
         entries = [
@@ -1624,6 +1630,7 @@ def main():
         ]
         do_concat = False
         do_export = False
+        do_import_only = False
 
     if not entries:
         print("No files to process")
@@ -1644,26 +1651,27 @@ def main():
         return
 
     if do_concat:
-        # All files go into one timeline; subtitles generated once across the whole thing
         import_paths = [conv if conv else src for src, conv in valid_entries]
         first_src = valid_entries[0][0]
         timeline_name = os.path.basename(first_src)
         srt_path = os.path.splitext(first_src)[0] + ".srt"
-        export = do_export  # off by default for concat unless --export given
+        export = do_export and not do_import_only
 
         names = ", ".join(os.path.basename(s) for s, _ in valid_entries)
         print(f"\nConcat mode: building one timeline from {len(valid_entries)} file(s): {names}")
-        if export:
+        if do_import_only:
+            print("  Import only — subtitle generation skipped")
+        elif export:
             print(f"  SRT will be exported to: {srt_path}")
         else:
             print("  Subtitles will be generated in Resolve only (use --export to save SRT)")
 
-        if generate_srt(import_paths, timeline_name, srt_path, do_export=export):
-            print(f"Successfully generated subtitles for concat timeline '{timeline_name}'")
+        if generate_srt(import_paths, timeline_name, srt_path, do_export=export, do_import_only=do_import_only):
+            print(f"Successfully {'imported' if do_import_only else 'generated subtitles for'} concat timeline '{timeline_name}'")
             if export:
                 print(f"SRT saved to: {srt_path}")
         else:
-            print("Failed to generate subtitles for concat timeline")
+            print("Failed to process concat timeline")
         return
 
     # Normal per-file processing
@@ -1675,18 +1683,32 @@ def main():
             if conv:
                 print(f"  Using converted file: {conv}")
 
-            srt_path = os.path.splitext(src)[0] + ".srt"
-            if generate_srt_for_file(import_path, srt_output_path=srt_path):
-                successful += 1
-                print(f"Successfully generated SRT for {os.path.basename(src)}")
+            if do_import_only:
+                if generate_srt(
+                    [import_path],
+                    os.path.basename(import_path),
+                    srt_output_path=None,
+                    do_export=False,
+                    do_import_only=True,
+                ):
+                    successful += 1
+                    print(f"Successfully imported {os.path.basename(src)}")
+                else:
+                    print(f"Failed to import {os.path.basename(src)}")
             else:
-                print(f"Failed to generate SRT for {os.path.basename(src)}")
+                srt_path = os.path.splitext(src)[0] + ".srt"
+                if generate_srt_for_file(import_path, srt_output_path=srt_path):
+                    successful += 1
+                    print(f"Successfully generated SRT for {os.path.basename(src)}")
+                else:
+                    print(f"Failed to generate SRT for {os.path.basename(src)}")
 
         except Exception as e:
             print(f"Error processing {os.path.basename(src)}: {str(e)}")
             continue
 
-    print(f"\nProcessed {len(valid_entries)} file(s), {successful} successful")
+    action = "imported" if do_import_only else "processed"
+    print(f"\n{successful}/{len(valid_entries)} file(s) {action} successfully")
 
 if __name__ == "__main__":
     main() 

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -858,14 +858,15 @@ def parse_args(argv):
     GLOBAL_FLAGS = {"--concat", "--export", "--import"}
 
     # Strip global flags first so they don't interfere with per-file parsing
-    do_concat = "--concat" in argv
-    do_export = "--export" in argv
-    do_import_only = "--import" in argv
-    argv = [a for a in argv if a not in GLOBAL_FLAGS]
+    argv_lower = [a.lower() for a in argv]
+    do_concat = "--concat" in argv_lower
+    do_export = "--export" in argv_lower
+    do_import_only = "--import" in argv_lower
+    argv = [a for a in argv if a.lower() not in GLOBAL_FLAGS]
 
     def is_convert_flag(token):
         """Return the format string if token is a supported --<fmt> flag, else None."""
-        return token[2:] if token in CONVERT_FLAGS else None
+        return token[2:].lower() if token.lower() in CONVERT_FLAGS else None
 
     def peek_flag(argv, i):
         """Return (fmt, output_dir, new_i) if argv[i] is a conversion flag, else (None, None, i)."""
@@ -1674,9 +1675,10 @@ def clear_subtitle_tracks(timeline):
 def main():
     # Handle conv-dir preference flags before anything else
     argv = sys.argv[1:]
+    argv_lower = [a.lower() for a in argv]
     for flag in CONV_DIR_FLAGS:
-        if flag in argv:
-            idx = argv.index(flag)
+        if flag in argv_lower:
+            idx = argv_lower.index(flag)
             value = argv[idx + 1] if idx + 1 < len(argv) else None
             handle_conv_dir_flag(value)
 

--- a/generate_srt.py
+++ b/generate_srt.py
@@ -770,17 +770,28 @@ def convert_audio(source_path, fmt, output_dir=None):
 
 
 def parse_args(argv):
-    """Parse argv into a list of (source_path, converted_path_or_None) tuples.
+    """Parse argv into entries and global flags.
 
-    Syntax per entry:
+    Returns:
+        entries   — list of (source_path, converted_path_or_None)
+        do_concat — True if --concat was present
+        do_export — True if --export was present
+
+    Per-file syntax:
         <file> [--<fmt> [dest_dir]]
 
-    --<fmt> can be any format ffmpeg supports (e.g. --wav, --mp3, --flac).
-    The optional dest_dir after the flag is consumed if the next token doesn't
-    look like an audio source file. Wildcards in file arguments are expanded.
+    Global flags (position-independent):
+        --concat   import all files into one timeline
+        --export   write the SRT file (override for --concat which skips export by default)
     """
     AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma", ".aiff"}
     CONVERT_FLAGS = {f"--{fmt}" for fmt in SUPPORTED_CONVERSION_FORMATS}
+    GLOBAL_FLAGS = {"--concat", "--export"}
+
+    # Strip global flags first so they don't interfere with per-file parsing
+    do_concat = "--concat" in argv
+    do_export = "--export" in argv
+    argv = [a for a in argv if a not in GLOBAL_FLAGS]
 
     def is_convert_flag(token):
         """Return the format string if token is a supported --<fmt> flag, else None."""
@@ -835,7 +846,7 @@ def parse_args(argv):
             else:
                 entries.append((source, None))
 
-    return entries
+    return entries, do_concat, do_export
 
 def get_audio_duration(audio_file):
     """Get the duration of an audio file in seconds."""
@@ -1372,113 +1383,148 @@ def get_current_project():
         logging.error(f"Error getting current project: {str(e)}")
         return None
 
-def generate_srt_for_file(audio_file, srt_output_path=None):
-    """Generate SRT file for a given audio file."""
-    try:
-        logging.info(f"Starting SRT generation for: {audio_file}")
+def build_timeline(project, media_pool, import_paths, timeline_name):
+    """Import all files and create a timeline with all clips in order.
 
-        # Get output path — use explicit path if provided (e.g. when audio_file is a temp conversion)
-        output_path = srt_output_path if srt_output_path else os.path.splitext(audio_file)[0] + ".srt"
-        logging.info(f"Output SRT will be saved to: {output_path}")
-        
-        # Get Resolve object
-        logging.info("Getting Resolve object...")
+    Works for both single-file and concat cases — a single file is just a
+    list of one.
+    """
+    try:
+        root_folder = media_pool.GetRootFolder()
+        if not root_folder:
+            logging.error("Failed to get root folder")
+            return None
+
+        media_items = []
+        for path in import_paths:
+            abs_path = os.path.abspath(os.path.normpath(path))
+            logging.info(f"Importing: {abs_path}")
+            items = media_pool.ImportMedia([abs_path])
+            if not items:
+                logging.error(f"Failed to import {abs_path}")
+                return None
+            if not verify_media_import(media_pool, items, abs_path):
+                logging.error(f"Media import verification failed for {abs_path}")
+                return None
+            media_items.append(items[0])
+
+        logging.info(f"Creating timeline '{timeline_name}' with {len(media_items)} clip(s)...")
+        timeline = media_pool.CreateTimelineFromClips(timeline_name, media_items)
+        if not timeline:
+            logging.error("Failed to create timeline")
+            return None
+
+        project.SetCurrentTimeline(timeline)
+        time.sleep(2)
+
+        current_timeline = project.GetCurrentTimeline()
+        if not current_timeline or current_timeline.GetName() != timeline_name:
+            logging.error("Failed to set timeline as current")
+            return None
+
+        items = current_timeline.GetItemListInTrack("audio", 1)
+        if not items:
+            logging.error("No media found in timeline after creation")
+            return None
+
+        logging.info("Successfully created timeline")
+        return current_timeline
+    except Exception as e:
+        logging.error(f"Error in build_timeline: {str(e)}")
+        return None
+
+
+def generate_srt(import_paths, timeline_name, srt_output_path, do_export=True):
+    """Core pipeline: import files, build timeline, generate subtitles, optionally export SRT.
+
+    import_paths   — list of file paths to import (one for normal, many for concat)
+    timeline_name  — name to give the timeline in Resolve
+    srt_output_path — where to write the SRT file (used only when do_export=True)
+    do_export      — write the SRT file when True; skip when False (concat default)
+    """
+    try:
+        logging.info(f"Starting SRT generation for: {import_paths}")
+        if do_export:
+            logging.info(f"Output SRT will be saved to: {srt_output_path}")
+
         resolve = get_resolve()
         if not resolve:
             logging.error("Failed to get Resolve object")
             return False
-            
-        # Get current project
-        logging.info("Getting current project...")
+
         project = get_current_project()
         if not project:
             logging.error("No project is open. Please open a project first.")
             return False
-            
-        # Get media pool
-        logging.info("Getting media pool...")
-        mediaPool = project.GetMediaPool()
-        if not mediaPool:
+
+        media_pool = project.GetMediaPool()
+        if not media_pool:
             logging.error("Failed to get media pool")
             return False
-            
-        # Get root folder
-        logging.info("Getting root folder...")
-        rootFolder = mediaPool.GetRootFolder()
-        if not rootFolder:
-            logging.error("Failed to get root folder")
-            return False
-            
-        # Import audio file
-        logging.info("Importing audio file...")
-        if not import_audio_file(mediaPool, rootFolder, audio_file):
-            logging.error("Failed to import audio file")
-            return False
-            
-        # Create timeline with media
-        logging.info("Creating timeline with media...")
-        timeline = create_timeline_with_media(project, mediaPool, os.path.basename(audio_file))
+
+        timeline = build_timeline(project, media_pool, import_paths, timeline_name)
         if not timeline:
-            logging.error("Failed to create timeline")
+            logging.error("Failed to build timeline")
             return False
-            
-        # Verify project state
-        logging.info("Verifying project state...")
+
         if not verify_project_state(project, timeline):
             logging.error("Project state verification failed")
             return False
-            
-        # Clear existing subtitle tracks
-        logging.info("Clearing existing subtitle tracks...")
+
         if not clear_subtitle_tracks(timeline):
             logging.error("Failed to clear subtitle tracks")
             return False
-            
-        # Setup timeline tracks
-        logging.info("Setting up timeline tracks...")
+
         if not setup_timeline_tracks(timeline):
             logging.error("Failed to setup timeline tracks")
             return False
-            
-        # Generate subtitles
-        logging.info("Generating subtitles...")
+
         if not create_subtitles_from_audio(timeline):
             logging.error("Failed to generate subtitles")
             return False
-            
-        # Wait for subtitle generation
-        logging.info("Waiting for subtitle generation (max 30 attempts)...")
+
         if not wait_for_subtitles(timeline):
-            logging.error("Failed to generate subtitles")
+            logging.error("Timed out waiting for subtitles")
             return False
-            
-        # Verify timeline is still valid
+
         if not verify_timeline(timeline):
-            logging.error("Timeline is no longer valid after generating subtitles")
+            logging.error("Timeline no longer valid after subtitle generation")
             return False
-            
-        # Get subtitle items
+
+        if not do_export:
+            logging.info("Subtitles generated in Resolve (export skipped)")
+            return True
+
         subtitle_items = get_subtitle_items(timeline)
         if not subtitle_items:
             logging.error("Failed to get subtitle items")
             return False
-            
-        # Get timeline framerate
+
         fps = get_timeline_framerate(timeline)
         logging.info(f"Using framerate: {fps} fps")
-            
-        # Write SRT file
-        logging.info(f"Writing SRT to: {output_path}")
-        if not write_srt_file(output_path, subtitle_items, fps):
+
+        logging.info(f"Writing SRT to: {srt_output_path}")
+        if not write_srt_file(srt_output_path, subtitle_items, fps):
             logging.error("Failed to write SRT file")
             return False
-            
-        logging.info(f"Successfully wrote SRT file to {output_path}")
+
+        logging.info(f"Successfully wrote SRT file to {srt_output_path}")
         return True
-        
+
     except Exception as e:
-        logging.error(f"Error in generate_srt_for_file: {str(e)}")
+        logging.error(f"Error in generate_srt: {str(e)}")
         return False
+
+
+def generate_srt_for_file(audio_file, srt_output_path=None):
+    """Thin wrapper around generate_srt for single-file callers."""
+    output_path = srt_output_path if srt_output_path else os.path.splitext(audio_file)[0] + ".srt"
+    return generate_srt(
+        import_paths=[audio_file],
+        timeline_name=os.path.basename(audio_file),
+        srt_output_path=output_path,
+        do_export=True,
+    )
 
 def verify_project_state(project, timeline):
     """Verify that the project and timeline are in a valid state."""
@@ -1553,14 +1599,15 @@ def clear_subtitle_tracks(timeline):
 def main():
     # Get files to process
     if len(sys.argv) > 1:
-        entries = parse_args(sys.argv[1:])
+        entries, do_concat, do_export = parse_args(sys.argv[1:])
     else:
-        # Process all MP3 files in samples directory
         samples_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "samples")
         entries = [
             (os.path.join(samples_dir, f), None)
             for f in os.listdir(samples_dir) if f.endswith('.MP3')
         ]
+        do_concat = False
+        do_export = False
 
     if not entries:
         print("No files to process")
@@ -1573,7 +1620,6 @@ def main():
             print(f"File not found, skipping: {src}")
             continue
         if conv == "FAILED":
-            # convert_audio failed; error already printed
             continue
         valid_entries.append((src, conv))
 
@@ -1581,32 +1627,30 @@ def main():
         print("No valid files to process")
         return
 
-    # Get initial Resolve setup
-    try:
-        resolve = get_resolve()
-        if not resolve:
-            print("Failed to get Resolve object")
-            return
+    if do_concat:
+        # All files go into one timeline; subtitles generated once across the whole thing
+        import_paths = [conv if conv else src for src, conv in valid_entries]
+        first_src = valid_entries[0][0]
+        timeline_name = os.path.basename(first_src)
+        srt_path = os.path.splitext(first_src)[0] + ".srt"
+        export = do_export  # off by default for concat unless --export given
 
-        project = get_current_project()
-        if not project:
-            print("No project is currently open. Please open a project first.")
-            return
+        names = ", ".join(os.path.basename(s) for s, _ in valid_entries)
+        print(f"\nConcat mode: building one timeline from {len(valid_entries)} file(s): {names}")
+        if export:
+            print(f"  SRT will be exported to: {srt_path}")
+        else:
+            print("  Subtitles will be generated in Resolve only (use --export to save SRT)")
 
-        media_pool = project.GetMediaPool()
-        if not media_pool:
-            print("Failed to get media pool")
-            return
-
-        root_folder = media_pool.GetRootFolder()
-        if not root_folder:
-            print("Failed to get root folder")
-            return
-    except Exception as e:
-        print(f"Error setting up Resolve: {str(e)}")
+        if generate_srt(import_paths, timeline_name, srt_path, do_export=export):
+            print(f"Successfully generated subtitles for concat timeline '{timeline_name}'")
+            if export:
+                print(f"SRT saved to: {srt_path}")
+        else:
+            print("Failed to generate subtitles for concat timeline")
         return
 
-    # Process each file sequentially
+    # Normal per-file processing
     successful = 0
     for src, conv in valid_entries:
         import_path = conv if conv else src


### PR DESCRIPTION
Allows converting the format to something else before importing to generating subtitles. Useful in the case of AAC audio not being compatible with Linux DaVinci Resolve. Since AAC's are in MP4 files, we can run the script with `--mp3` if we want to import the MP4 with MP3 for audio instead of AAC. It can generate subtitles. We can also use `--import` if we just want to import it without generating subtitles. It works with converting to many audio and video formats, using FFMPEG as the backend for conversion. See the README for how to set that up if not already.